### PR TITLE
fix: do not generate params for requests if its specified as `none'

### DIFF
--- a/lib/lsp_codegen/request.ex
+++ b/lib/lsp_codegen/request.ex
@@ -22,9 +22,10 @@ defmodule LSPCodegen.Request do
 
   def new(request) do
     params =
-      case request[:params] do
-        params when is_list(params) -> for(p <- params, do: Type.new(p))
-        params -> Type.new(params)
+      case request do
+        %{params: params} when is_list(params) -> for(p <- params, do: Type.new(p))
+        %{params: params} -> Type.new(params)
+        _ -> :none
       end
 
     %__MODULE__{

--- a/priv/request.ex.eex
+++ b/priv/request.ex.eex
@@ -26,8 +26,8 @@ defmodule GenLSP.Requests.<%= LSPCodegen.Naming.name(@request) %> do<%= if @requ
     schema(__MODULE__, %{
       method: "<%= @request.method %>",
       jsonrpc: "2.0",
-      id: int(),
-      <%= unless @params == :none do %> params: <%= LSPCodegen.Schematic.to_string(@params, @metamodel) %> <% end %>
+      id: int(),<%= unless @params == :none do %>
+      params: <%= LSPCodegen.Schematic.to_string(@params, @metamodel) %> <% end %>
     })
   end
 

--- a/priv/request.ex.eex
+++ b/priv/request.ex.eex
@@ -15,7 +15,7 @@ defmodule GenLSP.Requests.<%= LSPCodegen.Naming.name(@request) %> do<%= if @requ
     field :method, String.t(), default: "<%= @request.method %>"
     field :jsonrpc, String.t(), default: "2.0"
     field :id, integer(), enforce: true
-    field :params, <%= LSPCodegen.Codegen.to_string(@params, @metamodel) %>
+    <%= unless @params == :none do %> field :params, <%= LSPCodegen.Codegen.to_string(@params, @metamodel) %> <% end %>
   end
 
   @type result :: <%= LSPCodegen.Codegen.to_string(@request.result, @metamodel) %>
@@ -27,7 +27,7 @@ defmodule GenLSP.Requests.<%= LSPCodegen.Naming.name(@request) %> do<%= if @requ
       method: "<%= @request.method %>",
       jsonrpc: "2.0",
       id: int(),
-      params: <%= LSPCodegen.Schematic.to_string(@params, @metamodel) %>
+      <%= unless @params == :none do %> params: <%= LSPCodegen.Schematic.to_string(@params, @metamodel) %> <% end %>
     })
   end
 

--- a/priv/request.ex.eex
+++ b/priv/request.ex.eex
@@ -14,8 +14,8 @@ defmodule GenLSP.Requests.<%= LSPCodegen.Naming.name(@request) %> do<%= if @requ
   typedstruct do
     field :method, String.t(), default: "<%= @request.method %>"
     field :jsonrpc, String.t(), default: "2.0"
-    field :id, integer(), enforce: true
-    <%= unless @params == :none do %> field :params, <%= LSPCodegen.Codegen.to_string(@params, @metamodel) %> <% end %>
+    field :id, integer(), enforce: true<%= unless @params == :none do %>
+    field :params, <%= LSPCodegen.Codegen.to_string(@params, @metamodel) %> <% end %>
   end
 
   @type result :: <%= LSPCodegen.Codegen.to_string(@request.result, @metamodel) %>


### PR DESCRIPTION
When the params is none, the client might send an empty map or map, depending on protocol version.  It does not really matter which type we get as it won't be used. This will move towards resolving: https://github.com/elixir-tools/gen_lsp/issues/30

